### PR TITLE
Fix length calculation of strings containing ANSII escape codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: go
 go:
   - tip
+
+notifications:
+    email: false

--- a/columnize.go
+++ b/columnize.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 )
 
+// Config is the configuration for columnize
 type Config struct {
 	// The string by which the lines of input will be split.
 	Delim string
@@ -20,7 +21,14 @@ type Config struct {
 	Empty string
 }
 
-// Returns a Config with default values.
+// Regular expression used to find/remove ANSII escape codes for color
+var ansiiColorCodeRegexp *regexp.Regexp
+
+func init() {
+	ansiiColorCodeRegexp = regexp.MustCompile("\x1b\\[[^m]+m")
+}
+
+// DefaultConfig returns a Config with default values.
 func DefaultConfig() *Config {
 	return &Config{
 		Delim:  "|",
@@ -43,6 +51,22 @@ func getElementsFromLine(config *Config, line string) []interface{} {
 	return elements
 }
 
+// runeLen calculates the number of runes in a string
+func runeLen(s string) int {
+	l := 0
+	for _ = range s {
+		l++
+	}
+	return l
+}
+
+// runeLenWithoutANSII calculates the number of visible runes in a string,
+// not counting ANSII escape codes for color
+func runeLenWithoutANSII(s string) int {
+	s = ansiiColorCodeRegexp.ReplaceAllString(s, "")
+	return runeLen(s)
+}
+
 // Examines a list of strings and determines how wide each column should be
 // considering all of the elements that need to be printed within it.
 func getWidthsFromLines(config *Config, lines []string) []int {
@@ -52,7 +76,7 @@ func getWidthsFromLines(config *Config, lines []string) []int {
 		elems := getElementsFromLine(config, line)
 		for i := 0; i < len(elems); i++ {
 			// remove color code for counting the length
-			l := len(removeColorCode(elems[i].(string)))
+			l := runeLenWithoutANSII(elems[i].(string))
 			if len(widths) <= i {
 				widths = append(widths, l)
 			} else if widths[i] < l {
@@ -62,24 +86,6 @@ func getWidthsFromLines(config *Config, lines []string) []int {
 	}
 	return widths
 }
-
-// Given a set of column widths and the number of columns in the current line,
-// returns a sprintf-style format string which can be used to print output
-// aligned properly with other lines using the same widths set.
-// func (c *Config) getStringFormat(widths []int, columns int) string {
-// 	// Start with the prefix, if any was given.
-// 	stringfmt := c.Prefix
-
-// 	// Create the format string from the discovered widths
-// 	for i := 0; i < columns && i < len(widths); i++ {
-// 		if i == columns-1 {
-// 			stringfmt += "%s\n"
-// 		} else {
-// 			stringfmt += fmt.Sprintf("%%-%ds%s", widths[i], c.Glue)
-// 		}
-// 	}
-// 	return stringfmt
-// }
 
 func (c *Config) getStringFormat(widths []int, elems []interface{}) string {
 	// Start with the prefix, if any was given.
@@ -91,7 +97,8 @@ func (c *Config) getStringFormat(widths []int, elems []interface{}) string {
 			stringfmt += "%s\n"
 		} else {
 			if containsColorCode(elems[i]) {
-				stringfmt += fmt.Sprintf("%%-%ds%s", widths[i]+colorCodeLen(elems[i].(string)), c.Glue)
+				addOn := runeLen(elems[i].(string)) - runeLenWithoutANSII(elems[i].(string))
+				stringfmt += fmt.Sprintf("%%-%ds%s", widths[i]+addOn, c.Glue)
 			} else {
 				stringfmt += fmt.Sprintf("%%-%ds%s", widths[i], c.Glue)
 			}
@@ -154,27 +161,11 @@ func SimpleFormat(lines []string) string {
 	return Format(lines, nil)
 }
 
-// containsColorCode returns true if the string contains an ANSII escape code for color
+// containsColorCode returns true if the string contains an ANSII escape code
 func containsColorCode(i interface{}) bool {
 	s, ok := i.(string)
 	if ok {
 		return strings.Contains(s, "\x1b[")
 	}
 	return false
-}
-
-// return length of a string, not including ANSII escape codes
-func colorCodeLen(s string) int {
-	withoutColorCodes := removeColorCode(s)
-	return len(s) - len(withoutColorCodes)
-}
-
-// remove ANSII escape color codes from a string
-func removeColorCode(s string) string {
-	if strings.Contains(s, "\x1b[") {
-		// remove various sorts of opening tags
-		re := regexp.MustCompile("\x1b" + `\[[^m]+m`)
-		s = re.ReplaceAllString(s, "")
-	}
-	return s
 }

--- a/columnize.go
+++ b/columnize.go
@@ -2,6 +2,7 @@ package columnize
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -102,7 +103,7 @@ func (c *Config) getStringFormat(widths []int, elems []interface{}) string {
 // MergeConfig merges two config objects together and returns the resulting
 // configuration. Values from the right take precedence over the left side.
 func MergeConfig(a, b *Config) *Config {
-	var result Config = *a
+	var result = *a
 
 	// Return quickly if either side was nil
 	if a == nil || b == nil {
@@ -148,11 +149,12 @@ func Format(lines []string, config *Config) string {
 	return result
 }
 
-// Convenience function for using Columnize as easy as possible.
+// SimpleFormat is a convenience function for using Columnize as easy as possible.
 func SimpleFormat(lines []string) string {
 	return Format(lines, nil)
 }
 
+// containsColorCode returns true if the string contains an ANSII escape code for color
 func containsColorCode(i interface{}) bool {
 	s, ok := i.(string)
 	if ok {
@@ -161,16 +163,18 @@ func containsColorCode(i interface{}) bool {
 	return false
 }
 
+// return length of a string, not including ANSII escape codes
 func colorCodeLen(s string) int {
 	withoutColorCodes := removeColorCode(s)
 	return len(s) - len(withoutColorCodes)
 }
 
+// remove ANSII escape color codes from a string
 func removeColorCode(s string) string {
 	if strings.Contains(s, "\x1b[") {
-		start := strings.Index(s, "m") + 1
-		end := strings.Index(s, "\x1b[0")
-		return s[start:end]
+		// remove various sorts of opening tags
+		re := regexp.MustCompile("\x1b" + `\[[^m]+m`)
+		s = re.ReplaceAllString(s, "")
 	}
 	return s
 }

--- a/columnize_test.go
+++ b/columnize_test.go
@@ -244,6 +244,17 @@ func TestMergeConfig(t *testing.T) {
 	}
 }
 
+func TestRemoveColorCode01(t *testing.T) {
+	input := "  \x1b[36;1mtest\x1b[0m  "
+	output := removeColorCode(input)
+	expected := "  test  "
+	if output != expected {
+		printableProof := fmt.Sprintf("\nGot:      %+q", output)
+		printableProof += fmt.Sprintf("\nExpected: %+q", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
 func TestDontCountColorCodes(t *testing.T) {
 	input := []string{
 		"\x1b[31;1mColumn A\x1b[0m | \x1b[32mColumn B\x1b[0m | \x1b[34mColumn C\x1b[0m",

--- a/columnize_test.go
+++ b/columnize_test.go
@@ -2,6 +2,7 @@ package columnize
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -74,6 +75,27 @@ func TestColumnWidthCalculator(t *testing.T) {
 
 	if output != expected {
 		t.Fatalf("\nexpected:\n%s\n\ngot:\n%s", expected, output)
+	}
+}
+
+func TestColumnWidthCalculatorNonASCII(t *testing.T) {
+	input := []string{
+		"Column A | Column B | Column C",
+		"⌘⌘⌘⌘⌘⌘⌘⌘ | Longer than B | Longer than C",
+		"short | short | short",
+	}
+
+	config := DefaultConfig()
+	output := Format(input, config)
+
+	expected := "Column A  Column B       Column C\n"
+	expected += "⌘⌘⌘⌘⌘⌘⌘⌘  Longer than B  Longer than C\n"
+	expected += "short     short          short"
+
+	if output != expected {
+		printableProof := fmt.Sprintf("\nGot:      %+q", output)
+		printableProof += fmt.Sprintf("\nExpected: %+q", expected)
+		t.Fatalf("\n%s", printableProof)
 	}
 }
 
@@ -244,14 +266,74 @@ func TestMergeConfig(t *testing.T) {
 	}
 }
 
-func TestRemoveColorCode01(t *testing.T) {
-	input := "  \x1b[36;1mtest\x1b[0m  "
-	output := removeColorCode(input)
-	expected := "  test  "
-	if output != expected {
-		printableProof := fmt.Sprintf("\nGot:      %+q", output)
-		printableProof += fmt.Sprintf("\nExpected: %+q", expected)
+func TestGetWidthsFromLines01(t *testing.T) {
+	config := DefaultConfig()
+	input := []string{"first|line", "second|line", "third     |line"}
+	expected := []int{6, 4}
+	output := getWidthsFromLines(config, input)
+	if !reflect.DeepEqual(output, expected) {
+		printableProof := fmt.Sprintf("\nGot:      %s", output)
+		printableProof += fmt.Sprintf("\nExpected: %s", expected)
 		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+func TestGetWidthsFromLines02(t *testing.T) {
+	config := DefaultConfig()
+	input := []string{"\x1b[32mfirst\x1b[0m|line", "second|line"}
+	expected := []int{6, 4}
+	output := getWidthsFromLines(config, input)
+	if !reflect.DeepEqual(output, expected) {
+		printableProof := fmt.Sprintf("\nGot:      %s", output)
+		printableProof += fmt.Sprintf("\nExpected: %s", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+// testing width calculation for non-ASCII cahracters
+func TestGetWidthsFromLines03(t *testing.T) {
+	config := DefaultConfig()
+	input := []string{"A|B", "⌘|⌘"}
+	expected := []int{1, 1}
+	output := getWidthsFromLines(config, input)
+	if !reflect.DeepEqual(output, expected) {
+		printableProof := fmt.Sprintf("\nGot:      %s", output)
+		printableProof += fmt.Sprintf("\nExpected: %s", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+// testing width calculation for strings with UTF-8 characters and color codes
+func TestGetWidthsFromLines04(t *testing.T) {
+	config := DefaultConfig()
+	input := []string{"\x1b[32m⌘\x1b[0m|⌘", "A|B"}
+	expected := []int{1, 1}
+	output := getWidthsFromLines(config, input)
+	if !reflect.DeepEqual(output, expected) {
+		printableProof := fmt.Sprintf("\nGot:      %s", output)
+		printableProof += fmt.Sprintf("\nExpected: %s", expected)
+		t.Fatalf("\n%s", printableProof)
+	}
+}
+
+func TestGetStringFormat01(t *testing.T) {
+	config := DefaultConfig()
+	widths := []int{13, 13, 3}
+	elems := getElementsFromLine(config, "first element | second element | end")
+	expected := "%-13s  %-13s  %s\n"
+	output := config.getStringFormat(widths, elems)
+	if output != expected {
+		t.Fatalf("\nGot:      %s\nExpected: %s", output, expected)
+	}
+}
+func TestGetStringFormat02(t *testing.T) {
+	config := DefaultConfig()
+	widths := []int{13, 13, 15, 3}
+	elems := getElementsFromLine(config, "first element | second item ⌘ | third element \x1b[32m⌘\x1b[0m | end")
+	output := config.getStringFormat(widths, elems)
+	expected := "%-13s  %-13s  %-24s  %s\n"
+	if output != expected {
+		t.Fatalf("\nGot:      %q\nExpected: %q", output, expected)
 	}
 }
 


### PR DESCRIPTION
This finally enables the robust combination of ANSII color codes and columnized output.

test program:

```golang
package main

import (
	"fmt"

	"github.com/fatih/color"
	"github.com/giantswarm/columnize"
)

func main() {
	input := []string{
		color.CyanString("Column A") + " | " + color.CyanString("Column B") + " | " + color.CyanString("Column C"),
		"Value A | some very long value | val C",
	}
	fmt.Println(columnize.SimpleFormat(input))
}

```